### PR TITLE
Handle LTS releases

### DIFF
--- a/src/main/java/io/quarkus/bot/release/step/AnnounceRelease.java
+++ b/src/main/java/io/quarkus/bot/release/step/AnnounceRelease.java
@@ -19,6 +19,7 @@ import io.quarkiverse.githubaction.Context;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.bot.release.ReleaseInformation;
 import io.quarkus.bot.release.ReleaseStatus;
+import io.quarkus.bot.release.util.Branches;
 import io.quarkus.bot.release.util.Repositories;
 import io.quarkus.bot.release.util.UpdatedIssueBody;
 import io.quarkus.bot.release.util.Versions;
@@ -43,9 +44,13 @@ public class AnnounceRelease implements StepHandler {
         comment.append("to trigger the performance evaluation testing for this release.\n\n");
 
         if (releaseInformation.isFinal()) {
-            comment.append("Then it is time to write the announcement:\n\n");
+            comment.append("Then it is time to announce the release:\n\n");
             if (!releaseInformation.isMaintenance()) {
-                comment.append("* Update the versions in `_data/versions.yaml`\n");
+                comment.append("* Update the versions of the website in [`_data/versions.yaml`](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/versions.yaml)\n");
+            }
+            if (Branches.isLts(releaseInformation.getBranch())) {
+                comment.append(
+                        "* This is a LTS version so make sure the version is referenced in the `documentation:` section of [`_data/versions.yaml`](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/versions.yaml)\n");
             }
             comment.append("* Write a blog post for [the website](https://github.com/quarkusio/quarkusio.github.io)\n");
             comment.append(

--- a/src/main/java/io/quarkus/bot/release/step/ApproveCoreRelease.java
+++ b/src/main/java/io/quarkus/bot/release/step/ApproveCoreRelease.java
@@ -14,6 +14,7 @@ import io.quarkiverse.githubaction.Context;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.bot.release.ReleaseInformation;
 import io.quarkus.bot.release.ReleaseStatus;
+import io.quarkus.bot.release.util.Branches;
 import io.quarkus.bot.release.util.Command;
 import io.quarkus.bot.release.util.Jdks;
 import io.quarkus.bot.release.util.Outputs;
@@ -39,7 +40,9 @@ public class ApproveCoreRelease implements StepHandler {
             comment.append("- :bulb: We detected that this `" + releaseInformation.getVersion() + "` release will be the first final as `"
                     + Versions.getDot0(releaseInformation.getVersion()) + "` has not been fully released\n");
         }
-        if (releaseInformation.isMaintenance()) {
+        if (Branches.isLts(releaseInformation.getBranch())) {
+            comment.append("- This is a `LTS` release.\n");
+        } else if (releaseInformation.isMaintenance()) {
             comment.append("- This is a `maintenance` release.\n");
         }
         if (!releaseInformation.isFinal()) {

--- a/src/main/java/io/quarkus/bot/release/step/CreateBranch.java
+++ b/src/main/java/io/quarkus/bot/release/step/CreateBranch.java
@@ -243,6 +243,10 @@ public class CreateBranch implements StepHandler {
                 + "- for fixes we also want in future " + previousMinorBranch + ", please add the triage/backport-" + previousMinorBranch + "? label\n";
 
         for (String ltsBranch : Branches.LTS_BRANCHES) {
+            if (ltsBranch.equals(releaseInformation.getBranch())) {
+                continue;
+            }
+
             email += "- for fixes we also want in future " + ltsBranch + ", please add the triage/backport-" + ltsBranch + "? label\n";
         }
 

--- a/src/main/java/io/quarkus/bot/release/step/UpdateQuickstarts.java
+++ b/src/main/java/io/quarkus/bot/release/step/UpdateQuickstarts.java
@@ -14,6 +14,7 @@ import io.quarkiverse.githubaction.Context;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.bot.release.ReleaseInformation;
 import io.quarkus.bot.release.ReleaseStatus;
+import io.quarkus.bot.release.util.Branches;
 import io.quarkus.bot.release.util.Processes;
 import io.quarkus.bot.release.util.UpdatedIssueBody;
 
@@ -27,7 +28,18 @@ public class UpdateQuickstarts implements StepHandler {
     @Override
     public int run(Context context, Commands commands, GitHub quarkusBotGitHub, ReleaseInformation releaseInformation,
             ReleaseStatus releaseStatus, GHIssue issue, UpdatedIssueBody updatedIssueBody) throws IOException, InterruptedException {
-        return processes.execute(List.of("./update-quickstarts.sh"));
+        int status = processes.execute(List.of("./update-quickstarts.sh"));
+
+        if (status != 0) {
+            return status;
+        }
+
+        // for LTS releases that are not maintenance release yet, we also push the version in a branch
+        if (Branches.isLts(releaseInformation.getBranch()) && !releaseInformation.isMaintenance()) {
+            status = processes.execute(List.of("./update-quickstarts.sh", releaseInformation.getBranch()));
+        }
+
+        return status;
     }
 
     @Override

--- a/src/main/java/io/quarkus/bot/release/util/Branches.java
+++ b/src/main/java/io/quarkus/bot/release/util/Branches.java
@@ -7,7 +7,7 @@ import io.quarkus.bot.release.ReleaseInformation;
 public class Branches {
 
     public static final String MAIN = "main";
-    public static final List<String> LTS_BRANCHES = List.of("3.2", "2.13");
+    public static final List<String> LTS_BRANCHES = List.of("3.8", "3.2", "2.13");
 
     public static String getPlatformPreparationBranch(ReleaseInformation releaseInformation) {
         if (releaseInformation.isFinal() && !releaseInformation.isFirstFinal()) {
@@ -23,6 +23,10 @@ public class Branches {
         }
 
         return MAIN;
+    }
+
+    public static boolean isLts(String branch) {
+        return LTS_BRANCHES.contains(branch);
     }
 
     private Branches() {

--- a/src/test/java/io/quarkus/bot/release/BranchesTest.java
+++ b/src/test/java/io/quarkus/bot/release/BranchesTest.java
@@ -33,4 +33,14 @@ public class BranchesTest {
         assertThat(Branches.getPlatformPreparationBranch(releaseInformation)).isEqualTo("3.6");
         assertThat(Branches.getPlatformReleaseBranch(releaseInformation)).isEqualTo("3.6");
     }
+
+    @Test
+    void testLts() {
+        assertThat(Branches.isLts("2.13")).isTrue();
+        assertThat(Branches.isLts("2.14")).isFalse();
+        assertThat(Branches.isLts("3.2")).isTrue();
+        assertThat(Branches.isLts("3.4")).isFalse();
+        assertThat(Branches.isLts("3.8")).isTrue();
+        assertThat(Branches.isLts("3.9")).isFalse();
+    }
 }


### PR DESCRIPTION
Until now, LTS releases were handled as maintenance releases as they would become LTS when the extended maitenance would have started.

This is no longer the case and we need to take extra care of it, especially to push the documentation in a versioned directory and the quickstarts to a versioned branch.