### PR TITLE
Reduce the initial delay when polling sync artifacts

### DIFF
--- a/src/main/java/io/quarkus/bot/release/step/SyncCoreRelease.java
+++ b/src/main/java/io/quarkus/bot/release/step/SyncCoreRelease.java
@@ -51,8 +51,8 @@ public class SyncCoreRelease implements StepHandler {
                     + "* Wait some more if it still returns a 404.\n\n"
                     + "Once the artifact is available, wait for an additional 20 minutes then you can continue with the release by adding a `"
                     + Command.CONTINUE.getFullCommand() + "` comment.");
-            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "30");
-            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "5");
+            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "20");
+            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "7");
             inputs.put(MonitorArtifactPublicationInputKeys.POLL_DELAY, "10");
             inputs.put(MonitorArtifactPublicationInputKeys.POST_DELAY, "20");
 

--- a/src/main/java/io/quarkus/bot/release/step/SyncPlatformRelease.java
+++ b/src/main/java/io/quarkus/bot/release/step/SyncPlatformRelease.java
@@ -53,8 +53,8 @@ public class SyncPlatformRelease implements StepHandler {
                     + "* Wait some more if it still returns a 404.\n"
                     + "Once the artifact is available, wait for an additional 10 minutes then you can continue with the release by adding a `"
                     + Command.CONTINUE.getFullCommand() + "` comment.");
-            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "20");
-            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "5");
+            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "10");
+            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "6");
             inputs.put(MonitorArtifactPublicationInputKeys.POLL_DELAY, "10");
             inputs.put(MonitorArtifactPublicationInputKeys.POST_DELAY, "10");
 


### PR DESCRIPTION
Sync seems to be a lot faster these days so let's give it a chance. This might reduce the release process of 20 mn which is always good to take, especially since it's just idle time.