### PR TITLE
Revert "Reduce the initial delay when polling sync artifacts"

### DIFF
--- a/src/main/java/io/quarkus/bot/release/step/ReleaseGradlePlugin.java
+++ b/src/main/java/io/quarkus/bot/release/step/ReleaseGradlePlugin.java
@@ -30,4 +30,9 @@ public class ReleaseGradlePlugin implements StepHandler {
         return processes.execute(List.of("./release-gradle-plugin.sh"));
     }
 
+    @Override
+    public String getErrorHelp(ReleaseInformation releaseInformation) {
+        return "The problem might be that not all the artifacts have been synced to Maven Central.";
+    }
+
 }

--- a/src/main/java/io/quarkus/bot/release/step/SyncCoreRelease.java
+++ b/src/main/java/io/quarkus/bot/release/step/SyncCoreRelease.java
@@ -51,8 +51,8 @@ public class SyncCoreRelease implements StepHandler {
                     + "* Wait some more if it still returns a 404.\n\n"
                     + "Once the artifact is available, wait for an additional 20 minutes then you can continue with the release by adding a `"
                     + Command.CONTINUE.getFullCommand() + "` comment.");
-            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "20");
-            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "7");
+            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "30");
+            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "5");
             inputs.put(MonitorArtifactPublicationInputKeys.POLL_DELAY, "10");
             inputs.put(MonitorArtifactPublicationInputKeys.POST_DELAY, "20");
 

--- a/src/main/java/io/quarkus/bot/release/step/SyncPlatformRelease.java
+++ b/src/main/java/io/quarkus/bot/release/step/SyncPlatformRelease.java
@@ -53,8 +53,8 @@ public class SyncPlatformRelease implements StepHandler {
                     + "* Wait some more if it still returns a 404.\n"
                     + "Once the artifact is available, wait for an additional 10 minutes then you can continue with the release by adding a `"
                     + Command.CONTINUE.getFullCommand() + "` comment.");
-            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "10");
-            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "6");
+            inputs.put(MonitorArtifactPublicationInputKeys.INITIAL_DELAY, "20");
+            inputs.put(MonitorArtifactPublicationInputKeys.POLL_ITERATIONS, "5");
             inputs.put(MonitorArtifactPublicationInputKeys.POLL_DELAY, "10");
             inputs.put(MonitorArtifactPublicationInputKeys.POST_DELAY, "10");
 


### PR DESCRIPTION
This reverts commit https://github.com/quarkusio/conversational-release-action/commit/7629dfa2699aaf68951e6f4c5e9c85734ce80b6d.

We never had a problem before this patch and I just got hit by artifacts
not being completely synced so let's get back to the previous values.