### PR TITLE
Use note instead of tip for error help

### DIFF
--- a/src/main/java/io/quarkus/bot/release/ReleaseAction.java
+++ b/src/main/java/io/quarkus/bot/release/ReleaseAction.java
@@ -384,7 +384,7 @@ public class ReleaseAction {
             StringBuilder interactionComment = new StringBuilder();
             interactionComment.append(Admonitions.caution(error)).append("\n\n");
             if (!Strings.isBlank(errorHelp)) {
-                interactionComment.append(Admonitions.tip(errorHelp)).append("\n\n");
+                interactionComment.append(Admonitions.note(errorHelp)).append("\n\n");
             }
             interactionComment.append("You can find more information about the failure in the [workflow run logs](").append(getWorkflowRunUrl(context)).append(").\n\n");
             interactionComment.append(Admonitions.important("This is not a fatal error, you can retry by adding a `" + Command.RETRY.getFullCommand() + "` comment.")).append("\n\n");


### PR DESCRIPTION
We have an error, we shouldn't have any green in the comment.