### PR TITLE
Adjust Platform release process for LTS regular release cadence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             <version>3.27.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/io/quarkus/bot/release/ReleaseInformation.java
+++ b/src/main/java/io/quarkus/bot/release/ReleaseInformation.java
@@ -103,15 +103,6 @@ public class ReleaseInformation {
     }
 
     @JsonIgnore
-    public boolean isFirstMicroMaintenanceRelease() {
-        if (version == null) {
-            throw new IllegalStateException("Unable to know if the version is the first micro maintenance at this stage");
-        }
-
-        return Versions.isFirstMicroMaintenanceRelease(version);
-    }
-
-    @JsonIgnore
     public boolean isFirstCR() {
         return "CR1".equalsIgnoreCase(qualifier);
     }
@@ -123,6 +114,15 @@ public class ReleaseInformation {
     @JsonIgnore
     public boolean isOriginBranchMain() {
         return Branches.MAIN.equals(originBranch);
+    }
+
+    @JsonIgnore
+    public boolean isLtsMaintenanceReleaseWithRegularReleaseCadence() {
+        if (version == null) {
+            throw new IllegalStateException("Unable to know if the version is a LTS maintenance release with regular release cadence at this stage");
+        }
+
+        return Branches.isLtsBranchWithRegularReleaseCadence(branch) && isFinal() && !isFirstFinal();
     }
 
     @Override

--- a/src/main/java/io/quarkus/bot/release/step/PreparePlatform.java
+++ b/src/main/java/io/quarkus/bot/release/step/PreparePlatform.java
@@ -40,6 +40,12 @@ public class PreparePlatform implements StepHandler {
             comment.append(Admonitions.warning("**This is the `.0` release so we update the Platform first then wait one week for the Platform members to contribute their updates then we release. Make sure you follow the instructions closely.**") + "\n\n");
         }
 
+        if (releaseInformation.isLtsMaintenanceReleaseWithRegularReleaseCadence()) {
+            comment.append(Admonitions.warning(
+                    "**This is a maintenance release for a LTS version with regular release cadence so we update the Platform first then wait one week for the Platform members to potentially contribute compatibility fixes then we release. Make sure you follow the instructions closely.**")
+                    + "\n\n");
+        }
+
         if (!releaseInformation.isFinal() && releaseInformation.isOriginBranchMain()) {
             comment.append(Admonitions.tip("In the case of `preview releases` (e.g. `Alpha1`, `CR1`...), the release will be built from the `main` branch") + "\n\n");
         }
@@ -93,7 +99,7 @@ public class PreparePlatform implements StepHandler {
                     + "The Quarkus " + releaseInformation.getVersion() + " core artifacts are available on Maven Central.\n"
                     + "\n"
                     + "The pull request updating the Platform to Quarkus " + releaseInformation.getVersion() + " has been merged in the main branch.\n"
-                    + "We pinged the team maintaining components not passing the tests in the pull request.\n"
+                    + "We pinged in the pull request the teams maintaining components not passing the tests.\n"
                     + "\n"
                     + "If you want to update your components, please create your pull requests targeting the main branch and make sure they are merged before next Tuesday.\n");
             if (!releaseInformation.isOriginBranchMain()) {
@@ -101,6 +107,32 @@ public class PreparePlatform implements StepHandler {
                         + releaseInformation.getBranch() + " branch as " + releaseInformation.getBranch()
                         + " has already been branched, given it is a LTS.\n");
             }
+            comment.append("\n"
+                    + "Thanks.\n"
+                    + "\n"
+                    + "--\n"
+                    + "The Quarkus dev team\n"
+                    );
+            comment.append("```\n\n");
+            comment.append("* If CI failed for some Platform members, please contact them so that they are aware of the issues\n\n");
+            comment.append(Admonitions.warning("**IMPORTANT - STOP HERE**\n**IMPORTANT - Wait a week before continuing with the Platform release**") + "\n\n");
+        }
+        if (releaseInformation.isLtsMaintenanceReleaseWithRegularReleaseCadence()) {
+            comment.append("* Send an email to the Platform coordination mailing list: [quarkus-platform-coordination@googlegroups.com](mailto:quarkus-platform-coordination@googlegroups.com) :\n\n");
+            comment.append("Subject:\n");
+            comment.append("```\n");
+            comment.append("Quarkus " + releaseInformation.getFullVersion() + " core artifacts are available\n");
+            comment.append("```\n");
+            comment.append("Body:\n");
+            comment.append("```\n");
+            comment.append("Hi,\n"
+                    + "\n"
+                    + "The Quarkus " + releaseInformation.getFullVersion() + " core artifacts are available on Maven Central.\n"
+                    + "\n"
+                    + "The pull request updating the Platform to Quarkus " + releaseInformation.getFullVersion() + " has been merged in the main branch.\n"
+                    + "We pinged in the pull request the teams maintaining components not passing the tests.\n"
+                    + "\n"
+                    + "If you need to update your components to fix compatibility issues with this new micro (and only for this reason!), please create your pull requests targeting the " + releaseInformation.getBranch() + " branch and make sure they are merged before next Monday.\n");
             comment.append("\n"
                     + "Thanks.\n"
                     + "\n"

--- a/src/main/java/io/quarkus/bot/release/util/Branches.java
+++ b/src/main/java/io/quarkus/bot/release/util/Branches.java
@@ -11,6 +11,7 @@ public class Branches {
     public static final String MAIN = "main";
     private static final List<String> LTS_BRANCHES = List.of("3.20", "3.15", "3.8", "3.2", "2.13");
     public static final String BRANCH_2_13 = "2.13";
+    public static final String BRANCH_3_15 = "3.15";
 
     public static String getPlatformPreparationBranch(ReleaseInformation releaseInformation) {
         if (releaseInformation.isFinal() && !releaseInformation.isFirstFinal()) {
@@ -55,6 +56,10 @@ public class Branches {
         }
 
         return branch;
+    }
+
+    public static boolean isLtsBranchWithRegularReleaseCadence(String branch) {
+        return Branches.isLts(branch) && new ComparableVersion(branch).compareTo(new ComparableVersion(BRANCH_3_15)) >= 0;
     }
 
     private Branches() {

--- a/src/test/java/io/quarkus/bot/release/ReleaseInformationTest.java
+++ b/src/test/java/io/quarkus/bot/release/ReleaseInformationTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.bot.release;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.quarkus.bot.release.util.Branches;
+
+public class ReleaseInformationTest {
+
+    @ParameterizedTest
+    // version,branch,qualifier,firstFinal,expectedResult
+    @CsvSource({ "3.6.0.CR1,3.6,CR1,false,false",
+            "3.8.2,3.8,,false,false",
+            "3.15.0.CR1,3.15,CR1,false,false",
+            "3.15.0,3.15,,true,false",
+            "3.15.1,3.15,,true,false",
+            "3.15.2,3.15,,false,true",
+            "3.16.2,3.16,,false,false",
+            "3.20.0,3.20,,true,false",
+            "3.20.1,3.20,,false,true"})
+    public void testIsLtsMaintenanceReleaseWithRegularReleaseCadence(ArgumentsAccessor argumentsAccessor) {
+        String version = argumentsAccessor.getString(0);
+        String branch = argumentsAccessor.getString(1);
+        String qualifier = argumentsAccessor.getString(2);
+        boolean firstFinal = argumentsAccessor.getBoolean(3);
+        boolean expectedResult = argumentsAccessor.getBoolean(4);
+
+        ReleaseInformation releaseInformation = new ReleaseInformation(version, branch, Branches.MAIN, qualifier, false, firstFinal, false);
+        assertThat(releaseInformation.isLtsMaintenanceReleaseWithRegularReleaseCadence()).as("Version %s", releaseInformation.getVersion()).isEqualTo(expectedResult);
+    }
+}


### PR DESCRIPTION
Chances are we will have to tune things a lot, thus why I decided to not be smart by combining this with existing corner cases.

So the idea here is that for LTS micro versions, we will also have to wait a week between core and platform (at least for now - things might be refined along the way, we will adjust accordingly).

This doesn't really change the scripts or anything, just the instructions you have to follow for the Platform step (it's the only one that still requires manual operations).