### PR TITLE
Support the ability to point to specific branch for emergency releases

### DIFF
--- a/src/main/java/io/quarkus/bot/release/ReleaseInformation.java
+++ b/src/main/java/io/quarkus/bot/release/ReleaseInformation.java
@@ -14,6 +14,7 @@ public class ReleaseInformation {
     private final String originBranch;
     private final String qualifier;
     private final boolean emergency;
+    private final String emergencyReleaseCoreBranch;
     private final boolean major;
 
     private String version;
@@ -22,14 +23,15 @@ public class ReleaseInformation {
 
     @JsonCreator
     public ReleaseInformation(String version, String branch, String originBranch, String qualifier, boolean emergency,
-            boolean major, boolean firstFinal, boolean maintenance) {
-        checkConsistency(branch, qualifier, emergency, major);
+            String emergencyReleaseCoreBranch, boolean major, boolean firstFinal, boolean maintenance) {
+        checkConsistency(branch, qualifier, emergency, emergencyReleaseCoreBranch, major);
 
         this.version = version;
         this.branch = branch;
         this.originBranch = originBranch;
         this.qualifier = qualifier;
         this.emergency = emergency;
+        this.emergencyReleaseCoreBranch = emergencyReleaseCoreBranch;
         this.major = major;
         this.firstFinal = firstFinal;
         this.maintenance = maintenance;
@@ -169,6 +171,14 @@ public class ReleaseInformation {
     }
 
     /**
+     * @return in the case of an emergency release, we might want to point to a branch that has been prepared specifically for
+     *         this emergency release.
+     */
+    public String getEmergencyReleaseCoreBranch() {
+        return emergencyReleaseCoreBranch;
+    }
+
+    /**
      * @return whether the origin branch for creating the branch is the main branch (see {@link #getOriginBranch()} for more
      *         details)
      */
@@ -191,7 +201,8 @@ public class ReleaseInformation {
         return Branches.isLtsBranchWithRegularReleaseCadence(branch) && isFinal() && !isFirstFinal();
     }
 
-    private static void checkConsistency(String branch, String qualifier, boolean emergency, boolean major) {
+    private static void checkConsistency(String branch, String qualifier, boolean emergency,
+            String emergencyReleaseCoreBranch, boolean major) {
         if (emergency) {
             if (!Branches.isLtsBranchWithRegularReleaseCadence(branch)) {
                 throw new IllegalStateException(
@@ -203,6 +214,8 @@ public class ReleaseInformation {
             if (qualifier != null) {
                 throw new IllegalStateException("An emergency release may not have a qualifier");
             }
+        } else if (emergencyReleaseCoreBranch != null) {
+            throw new IllegalStateException("An emergency release Core branch may only be defined for emergency releases");
         }
     }
 
@@ -220,10 +233,11 @@ public class ReleaseInformation {
         if (getClass() != obj.getClass())
             return false;
         ReleaseInformation other = (ReleaseInformation) obj;
-        return Objects.equals(version, this.version)
+        return Objects.equals(version, other.version)
                 && Objects.equals(branch, other.branch)
                 && Objects.equals(originBranch, other.originBranch)
                 && emergency == other.emergency
+                && Objects.equals(emergencyReleaseCoreBranch, other.emergencyReleaseCoreBranch)
                 && major == other.major
                 && Objects.equals(qualifier, other.qualifier)
                 && firstFinal == other.firstFinal
@@ -233,7 +247,8 @@ public class ReleaseInformation {
     @Override
     public String toString() {
         return "ReleaseInformation [version=" + version + ", branch=" + branch + ", originBranch=" + originBranch
-                + ", qualifier=" + qualifier + ", emergency=" + emergency + ", major=" + major
+                + ", qualifier=" + qualifier + ", emergency=" + emergency
+                + ", emergencyReleaseCoreBranch=" + emergencyReleaseCoreBranch + ", major=" + major
                 + ", firstFinal=" + firstFinal + ", maintenance=" + maintenance
                 + "]";
     }

--- a/src/main/java/io/quarkus/bot/release/step/Prerequisites.java
+++ b/src/main/java/io/quarkus/bot/release/step/Prerequisites.java
@@ -48,6 +48,9 @@ public class Prerequisites implements StepHandler {
         }
         if (releaseInformation.isEmergency()) {
             command.add("--emergency");
+            if (releaseInformation.getEmergencyReleaseCoreBranch() != null) {
+                command.add("--emergency-release-core-branch=" + releaseInformation.getEmergencyReleaseCoreBranch());
+            }
         }
         if (releaseInformation.isMajor()) {
             command.add("--major");

--- a/src/test/java/io/quarkus/bot/release/BranchesTest.java
+++ b/src/test/java/io/quarkus/bot/release/BranchesTest.java
@@ -12,7 +12,8 @@ public class BranchesTest {
 
     @Test
     void testPreviewRelease() {
-        ReleaseInformation releaseInformation = new ReleaseInformation("3.6.0.CR1", "3.6", Branches.MAIN, "CR1", false, false,
+        ReleaseInformation releaseInformation = new ReleaseInformation("3.6.0.CR1", "3.6", Branches.MAIN, "CR1", false, null,
+                false,
                 false, false);
 
         assertThat(Branches.getPlatformPreparationBranch(releaseInformation)).isEqualTo(Branches.MAIN);
@@ -21,7 +22,8 @@ public class BranchesTest {
 
     @Test
     void testFirstFinalRelease() {
-        ReleaseInformation releaseInformation = new ReleaseInformation("3.6.0", "3.6", Branches.MAIN, null, false, false, true,
+        ReleaseInformation releaseInformation = new ReleaseInformation("3.6.0", "3.6", Branches.MAIN, null, false, null, false,
+                true,
                 false);
 
         assertThat(Branches.getPlatformPreparationBranch(releaseInformation)).isEqualTo(Branches.MAIN);
@@ -30,7 +32,8 @@ public class BranchesTest {
 
     @Test
     void testFirstFinalLtsRelease() {
-        ReleaseInformation releaseInformation = new ReleaseInformation("3.20.0", "3.20", Branches.MAIN, null, false, false,
+        ReleaseInformation releaseInformation = new ReleaseInformation("3.20.0", "3.20", Branches.MAIN, null, false, null,
+                false,
                 true, false);
 
         assertThat(Branches.getPlatformPreparationBranch(releaseInformation)).isEqualTo("3.20");
@@ -39,7 +42,8 @@ public class BranchesTest {
 
     @Test
     void testBugfixFinalRelease() {
-        ReleaseInformation releaseInformation = new ReleaseInformation("3.6.1", "3.6", Branches.MAIN, null, false, false, false,
+        ReleaseInformation releaseInformation = new ReleaseInformation("3.6.1", "3.6", Branches.MAIN, null, false, null, false,
+                false,
                 false);
 
         assertThat(Branches.getPlatformPreparationBranch(releaseInformation)).isEqualTo("3.6");

--- a/src/test/java/io/quarkus/bot/release/ReleaseInformationTest.java
+++ b/src/test/java/io/quarkus/bot/release/ReleaseInformationTest.java
@@ -29,7 +29,8 @@ public class ReleaseInformationTest {
         boolean firstFinal = argumentsAccessor.getBoolean(3);
         boolean expectedResult = argumentsAccessor.getBoolean(4);
 
-        ReleaseInformation releaseInformation = new ReleaseInformation(version, branch, Branches.MAIN, qualifier, false, false,
+        ReleaseInformation releaseInformation = new ReleaseInformation(version, branch, Branches.MAIN, qualifier, false, null,
+                false,
                 firstFinal, false);
         assertThat(releaseInformation.isLtsMaintenanceReleaseWithRegularReleaseCadence())
                 .as("Version %s", releaseInformation.getVersion()).isEqualTo(expectedResult);


### PR DESCRIPTION
/cc @jmartisk - I don't think it's viable long term to revert the content of the branch for emergency releases so the idea would be to prepare a specific branch based on previous tag with only the commits we want and then point the release process to it.

For now I only implemented it for the Core repository.