### PR TITLE
Fix issue with new JBang version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,9 +66,9 @@ runs:
         echo "Java 21: ${JAVA_HOME_21_X64}"
         if [[ -n "${JAVA_HOME_21_X64}" ]]; then
           echo "Installing ${JAVA_HOME_21_X64} as JDK 21 for JBang"
-          jbang --verbose jdk install 21 ${JAVA_HOME_21_X64}
+          jbang --verbose jdk install java-21 ${JAVA_HOME_21_X64}
         fi
-        jbang --java 21 --fresh --repos 'quarkus-github-action=https://maven.pkg.github.com/quarkusio/conversational-release-action/' --repos 'mavencentral' io.quarkus.bot:conversational-release-action:999-SNAPSHOT
+        jbang --java java-21 --fresh --repos 'quarkus-github-action=https://maven.pkg.github.com/quarkusio/conversational-release-action/' --repos 'mavencentral' io.quarkus.bot:conversational-release-action:999-SNAPSHOT
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}


### PR DESCRIPTION
```
[jbang] [2026-06-24 11:31:36] Using JDK provider(s): CurrentJdkProvider, DefaultJdkProvider, JavaHomeJdkProvider, PathJdkProvider, LinkedJdkProvider, JBangJdkProvider
Error:  [0:219] [ERROR] When providing an existing JDK path, the versionOrId parameter must be a non-integer id
java.lang.IllegalArgumentException: When providing an existing JDK path, the versionOrId parameter must be a non-integer id
    at dev.jbang.cli.Jdk$JdkInstall.doCall(Jdk.java:123)
    at dev.jbang.cli.BaseCommand.execute(BaseCommand.java:134)
    at org.aesh.command.impl.operator.EndOperator.execute(EndOperator.java:41)
    at org.aesh.command.impl.Executions$ExecutionImpl.execute(Executions.java:239)
    at org.aesh.command.impl.AeshCommandRuntime.runExecutor(AeshCommandRuntime.java:222)
    at org.aesh.command.impl.AeshCommandRuntime.executeCommand(AeshCommandRuntime.java:175)
    at org.aesh.AeshRuntimeRunner.execute(AeshRuntimeRunner.java:160)
    at dev.jbang.Main.main(Main.java:46)
```