### PR TITLE
Bring back Java installation for JBang

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,11 @@ runs:
     - name: Run the action
       id: action
       run: |
+        echo "Java 21: ${JAVA_HOME_21_X64}"
+        if [[ -n "${JAVA_HOME_21_X64}" ]]; then
+          echo "Installing ${JAVA_HOME_21_X64} as JDK 21 for JBang"
+          jbang --verbose jdk install java-21 ${JAVA_HOME_21_X64}
+        fi
         jbang --java 21 --fresh --repos 'quarkus-github-action=https://maven.pkg.github.com/quarkusio/conversational-release-action/' --repos 'mavencentral' io.quarkus.bot:conversational-release-action:999-SNAPSHOT
       shell: bash
       env:


### PR DESCRIPTION
JBang is now stricter and the installation name can't be numeric.

The installation is automatically detected when selecting a Java version.