### PR TITLE
Move the wait at the right place during Platform release

### DIFF
--- a/src/main/java/io/quarkus/bot/release/step/PlatformReleaseMonitorCI.java
+++ b/src/main/java/io/quarkus/bot/release/step/PlatformReleaseMonitorCI.java
@@ -117,10 +117,7 @@ public class PlatformReleaseMonitorCI implements StepHandler {
             }
 
             issue.comment(":white_check_mark: Platform pull request #" + prNumber + " has been merged.\n\n"
-                    + "Waiting 15 minutes before continuing to let artifacts propagate...\n\n"
                     + Progress.youAreHere(releaseInformation, releaseStatus));
-
-            Thread.sleep(15 * 60 * 1000L);
         }
 
         return StepResult.success();

--- a/src/main/java/io/quarkus/bot/release/step/PlatformReleasePrepare.java
+++ b/src/main/java/io/quarkus/bot/release/step/PlatformReleasePrepare.java
@@ -114,6 +114,11 @@ public class PlatformReleasePrepare implements StepHandler {
             ReleaseStatus releaseStatus, GHIssue issue, UpdatedIssueBody updatedIssueBody)
             throws IOException, InterruptedException {
 
+        issue.comment(":hourglass: Waiting 15 minutes before preparing the Platform to let Core artifacts propagate...\n\n"
+                + Progress.youAreHere(releaseInformation, releaseStatus));
+
+        Thread.sleep(15 * 60 * 1000L);
+
         String platformPreparationBranch = Branches.getPlatformPreparationBranch(releaseInformation);
 
         List<String> scriptCommand = new ArrayList<>();


### PR DESCRIPTION
We want to wait a bit before running the sync.